### PR TITLE
fix: transcript insertion at point-min

### DIFF
--- a/esi-dictate.el
+++ b/esi-dictate.el
@@ -161,7 +161,8 @@ instructions."
 semantics of intermittent results."
   (let* ((id (alist-get 'start transcription-item))
          (text (alist-get 'transcript (aref (alist-get 'alternatives (alist-get 'channel transcription-item)) 0)))
-         (prev-item (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item)))
+         (prev-item (when (> (overlay-end esi-dictate-context-overlay) (point-min))  ;; Ensure the overlay isn't at (point-min)
+                      (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item)))
 
     ;; Highlighted error - `(- (overlay-end esi-dictate-context-overlay) 1)` will try to subtract 1
     ;; from point-min (at beginning of buffer)

--- a/esi-dictate.el
+++ b/esi-dictate.el
@@ -162,6 +162,10 @@ semantics of intermittent results."
   (let* ((id (alist-get 'start transcription-item))
          (text (alist-get 'transcript (aref (alist-get 'alternatives (alist-get 'channel transcription-item)) 0)))
          (prev-item (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item)))
+
+    ;; Highlighted error - `(- (overlay-end esi-dictate-context-overlay) 1)` will try to subtract 1
+    ;; from point-min (at beginning of buffer)
+    
     ;; If previous item and current are the same utterance, delete the previous
     ;; item and then insert new one. This handles intermittent results from the
     ;; ASR.

--- a/esi-dictate.el
+++ b/esi-dictate.el
@@ -162,7 +162,7 @@ semantics of intermittent results."
   (let* ((id (alist-get 'start transcription-item))
          (text (alist-get 'transcript (aref (alist-get 'alternatives (alist-get 'channel transcription-item)) 0)))
          (prev-item (when (> (overlay-end esi-dictate-context-overlay) (point-min))  ;; Ensure the overlay isn't at (point-min)
-                      (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item)))
+                      (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item))))
 
     ;; Highlighted error - `(- (overlay-end esi-dictate-context-overlay) 1)` will try to subtract 1
     ;; from point-min (at beginning of buffer)

--- a/esi-dictate.el
+++ b/esi-dictate.el
@@ -163,10 +163,6 @@ semantics of intermittent results."
          (text (alist-get 'transcript (aref (alist-get 'alternatives (alist-get 'channel transcription-item)) 0)))
          (prev-item (when (> (overlay-end esi-dictate-context-overlay) (point-min))  ;; Ensure the overlay isn't at (point-min)
                       (get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item))))
-
-    ;; Highlighted error - `(- (overlay-end esi-dictate-context-overlay) 1)` will try to subtract 1
-    ;; from point-min (at beginning of buffer)
-    
     ;; If previous item and current are the same utterance, delete the previous
     ;; item and then insert new one. This handles intermittent results from the
     ;; ASR.


### PR DESCRIPTION
Fixes #4 

---
In the function `esi-dictate-insert`, `prev-item` is being set as:
```
(get-text-property (- (overlay-end esi-dictate-context-overlay) 1) 'esi-dictate-transcription-item)
```

At the beginning of a buffer, this leads to the observed error. The fix is to check for this edge-condition before the assignment, with:
```
when (> (overlay-end esi-dictate-context-overlay) (point-min))
```